### PR TITLE
Port process spawning to asyncio

### DIFF
--- a/ocrdbrowser/_docker.py
+++ b/ocrdbrowser/_docker.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-import logging
 
+import asyncio
+import logging
 import os.path as path
-import subprocess as sp
 from typing import Any, AsyncContextManager
 
 from ._browser import Channel, OcrdBrowser
@@ -11,11 +11,15 @@ from ._websocketchannel import WebSocketChannel
 
 _docker_run = "docker run --rm -d --name {} -v {}:/data -p {}:8085 ocrd-browser:latest"
 _docker_stop = "docker stop {}"
+_docker_kill = "docker kill {}"
 
 
-def _run_command(cmd: str, *args: Any) -> sp.CompletedProcess[str]:
-    command = cmd.format(*args).split()
-    return sp.run(command, stdout=sp.PIPE, text=True)
+async def _run_command(cmd: str, *args: Any) -> asyncio.subprocess.Process:
+    command = cmd.format(*args)
+    return await asyncio.create_subprocess_shell(
+        command,
+        stdout=asyncio.subprocess.PIPE,
+    )
 
 
 class DockerOcrdBrowser:
@@ -35,14 +39,14 @@ class DockerOcrdBrowser:
     def owner(self) -> str:
         return self._owner
 
-    def start(self) -> None:
-        cmd = _run_command(
+    async def start(self) -> None:
+        cmd = await _run_command(
             _docker_run, self._container_name(), self._workspace, self._port.get()
         )
         self.id = str(cmd.stdout).strip()
 
-    def stop(self) -> None:
-        cmd = _run_command(
+    async def stop(self) -> None:
+        cmd = await _run_command(
             _docker_stop, self._container_name(), self.workspace(), self._port.get()
         )
 
@@ -75,9 +79,9 @@ class DockerOcrdBrowserFactory:
         self._containers.append(container)
         return container
 
-    def stop_all(self) -> None:
+    async def stop_all(self) -> None:
         running_ids = [c.id for c in self._containers if c.id]
         if running_ids:
-            _run_command(_docker_stop, " ".join(running_ids))
+            await _run_command(_docker_kill, " ".join(running_ids))
 
         self._containers = []

--- a/ocrdbrowser/_subprocess.py
+++ b/ocrdbrowser/_subprocess.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
-import subprocess as sp
 from shutil import which
 from typing import AsyncContextManager, Optional
 
@@ -17,7 +18,7 @@ class SubProcessOcrdBrowser:
         self._localport = localport
         self._owner = owner
         self._workspace = workspace
-        self._process: Optional[sp.Popen[bytes]] = None
+        self._process: Optional[asyncio.subprocess.Process] = None
 
     def address(self) -> str:
         # as long as we do not have a reverse proxy on BW_PORT,
@@ -33,7 +34,7 @@ class SubProcessOcrdBrowser:
     def owner(self) -> str:
         return self._owner
 
-    def start(self) -> None:
+    async def start(self) -> None:
         browse_ocrd = which("browse-ocrd")
         if not browse_ocrd:
             raise FileNotFoundError("Could not find browse-ocrd executable")
@@ -47,7 +48,7 @@ class SubProcessOcrdBrowser:
         environment["GDK_BACKEND"] = "broadway"
         environment["BROADWAY_DISPLAY"] = ":" + displayport
 
-        self._process = sp.Popen(
+        self._process = await asyncio.create_subprocess_shell(
             " ".join(
                 [
                     "broadwayd",
@@ -57,14 +58,19 @@ class SubProcessOcrdBrowser:
                     "kill $!",
                 ]
             ),
-            shell=True,
             env=environment,
         )
 
-    def stop(self) -> None:
+    async def stop(self) -> None:
         if self._process:
-            self._process.terminate()
-            self._localport.release()
+            try:
+                self._process.terminate()
+            except ProcessLookupError:
+                logging.info(
+                    f"Attempted to stop already terminated process {self._process.pid}"
+                )
+            finally:
+                self._localport.release()
 
     def open_channel(self) -> AsyncContextManager[Channel]:
         return WebSocketChannel(self.address() + "/socket")

--- a/ocrdmonitor/server/workspaces.py
+++ b/ocrdmonitor/server/workspaces.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import uuid
 from pathlib import Path
 
@@ -76,7 +75,7 @@ def create_workspaces(
         redirect = redirects.get(session_id, workspace_path)
         try:
             return await proxy.forward(redirect, str(workspace_path))
-        except ConnectionError:
+        except httpx.ConnectError:
             return templates.TemplateResponse(
                 "view_workspace_failed.html.j2",
                 {"request": request, "workspace": workspace},
@@ -103,12 +102,10 @@ def create_workspaces(
                 pass
 
     async def launch_browser(session_id: str, workspace: Path) -> OcrdBrowser:
-        return await asyncio.to_thread(
-            ocrdbrowser.launch, str(workspace), session_id, factory
-        )
+        return await ocrdbrowser.launch(str(workspace), session_id, factory)
 
     async def stop_browser(browser: OcrdBrowser) -> None:
-        await asyncio.to_thread(browser.stop)
+        await browser.stop()
         key = Path(browser.workspace()).relative_to(workspace_dir)
         redirects.remove(browser.owner(), key)
 

--- a/tests/ocrdbrowser/browserdoubles.py
+++ b/tests/ocrdbrowser/browserdoubles.py
@@ -43,10 +43,10 @@ class BrowserSpy:
     def owner(self) -> str:
         return self.owner_name
 
-    def start(self) -> None:
+    async def start(self) -> None:
         self.running = True
 
-    def stop(self) -> None:
+    async def stop(self) -> None:
         self.running = False
 
     @asynccontextmanager

--- a/tests/ocrdbrowser/test_launch.py
+++ b/tests/ocrdbrowser/test_launch.py
@@ -1,13 +1,16 @@
 from typing import cast
 
+import pytest
+
 import ocrdbrowser
 from tests.ocrdbrowser.browserdoubles import BrowserSpy, BrowserTestDoubleFactory
 
 
-def test__workspace__launch__spawns_new_ocrd_browser() -> None:
+@pytest.mark.asyncio
+async def test__workspace__launch__spawns_new_ocrd_browser() -> None:
     owner = "the-owner"
     workspace = "path/to/workspace"
-    process = ocrdbrowser.launch(workspace, owner, BrowserTestDoubleFactory())
+    process = await ocrdbrowser.launch(workspace, owner, BrowserTestDoubleFactory())
 
     process = cast(BrowserSpy, process)
     assert process.running is True
@@ -15,11 +18,12 @@ def test__workspace__launch__spawns_new_ocrd_browser() -> None:
     assert process.workspace() == workspace
 
 
-def test__workspace__launch_for_different_owners__both_processes_running() -> None:
+@pytest.mark.asyncio
+async def test__workspace__launch_for_different_owners__both_processes_running() -> None:
     factory = BrowserTestDoubleFactory()
 
-    first_process = ocrdbrowser.launch("first-path", "first-owner", factory)
-    second_process = ocrdbrowser.launch(
+    first_process = await ocrdbrowser.launch("first-path", "first-owner", factory)
+    second_process = await ocrdbrowser.launch(
         "second-path", "second-owner", factory, {first_process}
     )
 
@@ -29,14 +33,17 @@ def test__workspace__launch_for_different_owners__both_processes_running() -> No
     assert {p.workspace() for p in processes} == {"first-path", "second-path"}
 
 
-def test__workspace__launch_for_same_owner_and_workspace__does_not_start_new_process() -> (
+@pytest.mark.asyncio
+async def test__workspace__launch_for_same_owner_and_workspace__does_not_start_new_process() -> (
     None
 ):
     owner = "the-owner"
     workspace = "the-workspace"
     factory = BrowserTestDoubleFactory()
 
-    first_process = ocrdbrowser.launch(workspace, owner, factory)
-    second_process = ocrdbrowser.launch(workspace, owner, factory, {first_process})
+    first_process = await ocrdbrowser.launch(workspace, owner, factory)
+    second_process = await ocrdbrowser.launch(
+        workspace, owner, factory, {first_process}
+    )
 
     assert first_process is second_process


### PR DESCRIPTION
Spawns browser subprocesses with `asyncio` instead of using the blocking `subprocess` module