### PR TITLE
Install monitor into separate venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,6 @@ COPY pyproject.toml /usr/local/ocrd-monitor/
 COPY noxfile.py /usr/local/ocrd-monitor/
 COPY tests /usr/local/ocrd-monitor/tests
 
-# RUN python3 -m venv /.venv && \
-#     . /.venv/bin/activate && \
-#     pip3 install -e /usr/local/ocrd-monitor
-
 RUN curl -sSL https://pdm.fming.dev/install-pdm.py | python3 - 
 ENV PATH="/root/.local/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,15 @@ COPY pyproject.toml /usr/local/ocrd-monitor/
 COPY noxfile.py /usr/local/ocrd-monitor/
 COPY tests /usr/local/ocrd-monitor/tests
 
-RUN pip install -e /usr/local/ocrd-monitor
+# RUN python3 -m venv /.venv && \
+#     . /.venv/bin/activate && \
+#     pip3 install -e /usr/local/ocrd-monitor
+
+RUN curl -sSL https://pdm.fming.dev/install-pdm.py | python3 - 
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /usr/local/ocrd-monitor
+RUN pdm install
 
 WORKDIR /
 CMD ["/init.sh", "/data"]

--- a/init.sh
+++ b/init.sh
@@ -28,4 +28,4 @@ export OCRD_CONTROLLER__USER=admin
 export OCRD_CONTROLLER__KEYFILE=~/.ssh/id_rsa
 
 cd /usr/local/ocrd-monitor
-uvicorn --host 0.0.0.0 --port 5000 "ocrdmonitor.main:app"
+pdm run monitor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ markers = [
 [tool.pdm.scripts]
 test = "pytest tests -m 'not integration'"
 test-integration = "pytest tests"
+monitor = "uvicorn --host 0.0.0.0 --port 5000 'ocrdmonitor.main:app'"
 
 [[tool.mypy.overrides]]
 module = ["testcontainers.*", "motor.motor_asyncio"]


### PR DESCRIPTION
Due to conflicts with `browse-ocrd` resulting from our upgraded `pydantic` version, the OCRD Monitor needs to be installed into a separate virtual environment.

I added PDM to the `Dockerfile` and set up a new command to run the monitor with PDM.