### PR TITLE
Set collection name to OcrdJob

### DIFF
--- a/ocrdmonitor/database/_ocrdjobrepository.py
+++ b/ocrdmonitor/database/_ocrdjobrepository.py
@@ -23,6 +23,7 @@ class MongoOcrdJob(Document):
     controller_address: str
 
     class Settings:
+        name = "OcrdJob"
         indexes = [
             pymongo.IndexModel(
                 [


### PR DESCRIPTION
Currently, the OcrdJobs are not being displayed, as they are being stored in a different collection than the one generated by "beanie." I renamed the beanie collection to "OcrdJob," as I believe it's better to have it named as such IMO.