### PR TITLE
Starting browser maximized and without edit/open functionality

### DIFF
--- a/ocrdbrowser/_subprocess.py
+++ b/ocrdbrowser/_subprocess.py
@@ -153,4 +153,11 @@ def browser_command(workspace: str, broadway_pid: int) -> str:
     mets_path = workspace + "/mets.xml"
     kill_broadway = f"; kill {broadway_pid}"
     browse_ocrd = cast(str, which("browse-ocrd"))
-    return " ".join([browse_ocrd, mets_path, kill_broadway])
+    return " ".join(
+        [
+            browse_ocrd,
+            "-mr",
+            mets_path,
+            kill_broadway,
+        ]
+    )


### PR DESCRIPTION
Open OCR-D browser in maximized and restricted window. The fullscreen parameter did not work as described here https://github.com/slub/ocrd_monitor/issues/7#issuecomment-1497448751